### PR TITLE
Add example to the documentation for ronn

### DIFF
--- a/file-generating/ronn/README.md
+++ b/file-generating/ronn/README.md
@@ -114,6 +114,12 @@ Viewing the manpage:
 $ man ./ronn.sif.1
 ```
 
+Alternately, view the manpage using the container:
+
+```
+$ ronn.sif  view ./ronn.sif.1
+```
+
 <br>
 
 ### More examples:
@@ -127,6 +133,7 @@ $ ronn.sif --gzip --html your_markdown_file.md
 Now you should have your `your_markdown_file.1.gzip`, and `your_markdown_file.1.html`.
 
 <br>
+
 
 ### Specifying the output file:
 

--- a/file-generating/ronn/template.md
+++ b/file-generating/ronn/template.md
@@ -19,7 +19,7 @@ more description on what it does
     whatever other options you want
 
 ## COMMANDS
-* `do`, `do-somthing` :
+* `do`, `do-something` :
     what your command does
 
 ## EXAMPLES


### PR DESCRIPTION
I found it handy to use the container to view the manpage that I generated using `ronn`. I added example syntax for this to the README. As a bonus, I made a slight spelling improvement to the manpage template. I hope it is all right that I bundled these into the same pull request. 