### PR TITLE
Updating jupyter install with python3

### DIFF
--- a/machinelearning/jupyter-notebook/README.md
+++ b/machinelearning/jupyter-notebook/README.md
@@ -2,24 +2,22 @@
 
 Jupyter Notebook is an open source web application environment that allows to create and share documents that contain code, equations, visualizations and narrative text. Some use cases are data visualization, statistical modeling and machine learning.
 
-The following example is based on Conda 4.5.11 (Canary) and Jupyter Notebook 5.6.0 for Debian 9.x (Stretch)
-
-#### Setting up the port and the ip:
+## Setting up the port and the ip
 
 You can edit the environment variables `JUP_PORT` and `JUP_IPNAME` from the definition file before building. Default values are set to port 8888 and ip localhost.
 Feel free to set up these variables according to your needs.
 
 After that, you can build your container with the following command:
 
-```
-$ sudo singularity build jupyter.sif jupyter.def
+```bash
+singularity build --fakeroot jupyter.sif jupyter.def
 ```
 
 The definition file above has a `%post` section in which all the dependencies are installed at build time. After that, you can start the container, it will listen by default on `localhost:8888`, you can do this by starting an instance of the Jupyter Notebook server:
 
-```
-$ sudo singularity instance start jupyter.sif jupyter
+```bash
+singularity instance start jupyter.sif jupyter
 ```
 
 See the write-up at:
-https://www.sylabs.io/2018/10/jupyter-notebook/
+[https://www.sylabs.io/2018/10/jupyter-notebook/](https://www.sylabs.io/2018/10/jupyter-notebook/)

--- a/machinelearning/jupyter-notebook/jupyter.def
+++ b/machinelearning/jupyter-notebook/jupyter.def
@@ -1,65 +1,24 @@
 Bootstrap: library
-From: debian:9
+From: ubuntu:22.04
 
 %environment
   JUP_PORT=8888
-  JUP_IPNAME=localhost
+  JUP_IPNAME=0.0.0.0
   export JUP_PORT JUP_IPNAME
-
-%help
-
-    Container with Anaconda 2 (Conda 4.5.11 Canary) and Jupyter Notebook 5.6.0 for Debian 9.x (Stretch).
-    This installation is based on Python 2.7.15
-
-%setup
-
-    #Create the .condarc file where the environments/channels from conda are specified, these are pulled with preference to root
-    cd /
-    touch .condarc
-
 %post
-
-    #Installing all dependencies
-
-    apt-get update && apt-get -y upgrade
-    apt-get -y install \
-    build-essential \
-    wget \
-    bzip2 \
-    ca-certificates \
-    libglib2.0-0 \
-    libxext6 \
-    libsm6 \
-    libxrender1 \
-    git
-
-   rm -rf /var/lib/apt/lists/*
-   apt-get clean
-
-  #Installing Anaconda 2 and Conda 4.5.11
-
-  wget -c https://repo.continuum.io/archive/Anaconda2-5.3.0-Linux-x86_64.sh
-    /bin/bash Anaconda2-5.3.0-Linux-x86_64.sh -bfp /usr/local
-
-  #Conda configuration of channels from .condarc file
-
-  conda config --file /.condarc --add channels defaults
-  conda config --file /.condarc --add channels conda-forge
-  conda update conda
-
-  #List installed environments
-  conda list
+  apt update
+  apt install -y python3-pip
+  pip install notebook
 
 %startscript
-
   PORT=""
   if [ -n "$JUP_PORT" ]; then
-    PORT="--port=${JUP_PORT}"
+     PORT="--port=${JUP_PORT}"
   fi
-
+  
   IPNAME=""
   if [ -n "$JUP_IPNAME" ]; then
     IPNAME="--ip=${JUP_IPNAME}"
   fi
 
-  exec jupyter notebook --allow-root ${PORT} ${IPNAME}
+  exec jupyter notebook ${PORT} ${IPNAME}


### PR DESCRIPTION
While working for Singularity 101 course, I came across these examples and found out the versions are very old, this is an update.

I do not understand why using conda if a pip install is enough to install it, maybe I am missing something. However this is an urgent update since the previous jupyter install was using ubuntu 16 and python 2.7.